### PR TITLE
Option for Deterministic ZipInfo

### DIFF
--- a/rezip.py
+++ b/rezip.py
@@ -16,6 +16,11 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--store", 
         help="Store data to stdout zip without compression",
         action="store_true")
+parser.add_argument("-d", "--deterministic",
+        help="Remove any file metadata in order to obtain a deterministic "\
+             "zip file. This is usefull in order to make sure that e.g. the "\
+             "modification date of the zipped files is irrelevant.",
+        action="store_true")
 args = parser.parse_args()
 if args.store:
     compression = ZIP_STORED
@@ -31,7 +36,12 @@ with io.BytesIO(sys.stdin.buffer.read()) as source, io.BytesIO() as dest:
     # Read and re-zip the file in memory
     with ZipFile(source, 'r') as source_zip, ZipFile(dest, 'w') as dest_zip:
         for info in source_zip.infolist(): # Iterate over each file in zip
-            dest_zip.writestr(info, source_zip.read(info), compression)
+            if args.deterministic:
+                newinfo = ZipInfo(info.filename)
+                newinfo.create_system = 0  # everything else is fixed
+            else:
+                newinfo = info
+            dest_zip.writestr(newinfo, source_zip.read(info), compression)
         dest_zip.comment = source_zip.comment # Copy the comment if any
 
     # Write the dest file as binary to stdout


### PR DESCRIPTION
Adds a `--deterministic` switch to `rezip.py`. All `ZipInfo` except for the filename is reverted to a default value, so metadata changes (especially timestamps) won't make git consider the file changed. The downside is of course, said metadata _could_ be important, therefore it's optional.